### PR TITLE
core: add support for groups chats into folders

### DIFF
--- a/app/src/main/java/io/shubham0204/smollmandroid/data/ChatsDB.kt
+++ b/app/src/main/java/io/shubham0204/smollmandroid/data/ChatsDB.kt
@@ -85,6 +85,11 @@ data class Chat(
      * They do not store conversation messages thus being 'stateless' in nature.
      */
     var isTask: Boolean = false,
+    /**
+     * The ID of the folder that this chat belongs to.
+     * -1 indicates that the chat does not belong to any folder.
+     */
+    var folderId: Long = -1L,
 )
 
 @Dao
@@ -101,9 +106,21 @@ interface ChatsDao {
     @Query("DELETE FROM Chat WHERE id = :chatId")
     suspend fun deleteChat(chatId: Long)
 
+    @Query("DELETE FROM Chat WHERE folderId = :folderId")
+    suspend fun deleteChatsInFolder(folderId: Long)
+
     @Update
     suspend fun updateChat(chat: Chat)
 
     @Query("SELECT COUNT(*) FROM Chat")
     suspend fun getChatsCount(): Long
+
+    @Query("SELECT * FROM Chat WHERE folderId = :folderId")
+    fun getChatsForFolder(folderId: Long): Flow<List<Chat>>
+
+    @Query("UPDATE Chat SET folderId = :newFolderId WHERE folderId = :oldFolderId")
+    fun updateFolderIds(
+        oldFolderId: Long,
+        newFolderId: Long,
+    )
 }

--- a/app/src/main/java/io/shubham0204/smollmandroid/data/FoldersDB.kt
+++ b/app/src/main/java/io/shubham0204/smollmandroid/data/FoldersDB.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2024 Shubham Panchal
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.shubham0204.smollmandroid.data
+
+import androidx.room.Dao
+import androidx.room.Entity
+import androidx.room.Insert
+import androidx.room.PrimaryKey
+import androidx.room.Query
+import androidx.room.Update
+import kotlinx.coroutines.flow.Flow
+
+@Entity(tableName = "Folder")
+data class Folder(
+    @PrimaryKey(autoGenerate = true) var id: Long = 0,
+    var name: String = "",
+)
+
+@Dao
+interface FolderDao {
+    @Insert
+    suspend fun insertFolder(folder: Folder)
+
+    @Update
+    suspend fun updateFolder(folder: Folder)
+
+    @Query("SELECT * FROM Folder")
+    fun getFolders(): Flow<List<Folder>>
+
+    @Query("DELETE FROM Folder WHERE id = :folderId")
+    suspend fun deleteFolder(folderId: Long)
+}

--- a/app/src/main/java/io/shubham0204/smollmandroid/ui/components/ModifierExtensions.kt
+++ b/app/src/main/java/io/shubham0204/smollmandroid/ui/components/ModifierExtensions.kt
@@ -1,0 +1,17 @@
+package io.shubham0204.smollmandroid.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+
+fun Modifier.noRippleClickable(onClick: () -> Unit): Modifier =
+    composed {
+        this.clickable(
+            indication = null,
+            interactionSource = remember { MutableInteractionSource() },
+        ) {
+            onClick()
+        }
+    }

--- a/app/src/main/java/io/shubham0204/smollmandroid/ui/components/TextFieldDialog.kt
+++ b/app/src/main/java/io/shubham0204/smollmandroid/ui/components/TextFieldDialog.kt
@@ -1,0 +1,114 @@
+package io.shubham0204.smollmandroid.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material.icons.filled.ArrowForward
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import io.shubham0204.smollmandroid.R
+
+private var title = ""
+private var defaultText = ""
+private var placeholder = ""
+private var buttonText = ""
+private lateinit var buttonOnClick: ((String) -> Unit)
+private val textFieldDialogShowStatus = mutableStateOf(false)
+
+@Composable
+fun TextFieldDialog() {
+    var visible by remember { textFieldDialogShowStatus }
+    if (visible) {
+        Surface {
+            Dialog(onDismissRequest = { visible = false }) {
+                Column(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .background(
+                                MaterialTheme.colorScheme.surfaceContainer,
+                                RoundedCornerShape(8.dp),
+                            ).padding(16.dp),
+                ) {
+                    var text by remember { mutableStateOf(defaultText) }
+                    var label by remember { mutableStateOf("") }
+                    var isError by remember { mutableStateOf(false) }
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.titleLarge,
+                        modifier = Modifier.fillMaxWidth(),
+                        textAlign = TextAlign.Center,
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    TextField(
+                        value = text,
+                        onValueChange = { text = it },
+                        placeholder = { Text(placeholder) },
+                        isError = isError,
+                        label = { Text(label) },
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceAround,
+                    ) {
+                        Button(onClick = {
+                            if (text.trim().isEmpty()) {
+                                label = "The field cannot be empty"
+                                isError = true
+                            } else {
+                                buttonOnClick(text)
+                                visible = false
+                            }
+                        }) {
+                            Icon(Icons.AutoMirrored.Filled.ArrowForward, contentDescription = null)
+                            Text(buttonText)
+                        }
+                        Button(onClick = { visible = false }) {
+                            Icon(Icons.Default.Close, contentDescription = null)
+                            Text(stringResource(R.string.dialog_err_close))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fun createTextFieldDialog(
+    dialogTitle: String,
+    dialogDefaultText: String,
+    dialogPlaceholder: String,
+    dialogButtonText: String,
+    onButtonClick: ((String) -> Unit),
+) {
+    title = dialogTitle
+    defaultText = dialogDefaultText
+    placeholder = dialogPlaceholder
+    buttonOnClick = onButtonClick
+    buttonText = dialogButtonText
+    textFieldDialogShowStatus.value = true
+}

--- a/app/src/main/java/io/shubham0204/smollmandroid/ui/screens/chat/ChangeFolderDialogUI.kt
+++ b/app/src/main/java/io/shubham0204/smollmandroid/ui/screens/chat/ChangeFolderDialogUI.kt
@@ -1,0 +1,84 @@
+package io.shubham0204.smollmandroid.ui.screens.chat
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import io.shubham0204.smollmandroid.R
+import io.shubham0204.smollmandroid.data.Chat
+import io.shubham0204.smollmandroid.data.Folder
+
+@Composable
+fun ChangeFolderDialogUI(
+    onDismissRequest: () -> Unit,
+    chat: Chat,
+    folders: List<Folder>,
+    onUpdateFolderId: (Long) -> Unit,
+) {
+    val modifiedFolders = ArrayList(folders)
+    modifiedFolders.add(0, Folder(id = -1L, name = "No Folder"))
+    var selectedFolderId by remember { mutableLongStateOf(chat.folderId) }
+    Surface {
+        Dialog(onDismissRequest) {
+            Column(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .background(
+                            MaterialTheme.colorScheme.surfaceContainer,
+                            RoundedCornerShape(8.dp),
+                        ).padding(16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text(
+                    text = stringResource(R.string.dialog_select_folder_title),
+                    style = MaterialTheme.typography.titleMedium,
+                )
+                LazyColumn {
+                    items(modifiedFolders) { folder ->
+                        Row(
+                            modifier =
+                                Modifier
+                                    .padding(8.dp)
+                                    .fillMaxWidth()
+                                    .clickable {
+                                        selectedFolderId = folder.id
+                                        onUpdateFolderId(folder.id)
+                                    },
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            RadioButton(selected = folder.id == selectedFolderId, onClick = null)
+                            Spacer(modifier = Modifier.width(4.dp))
+                            Text(folder.name)
+                        }
+                    }
+                }
+                Spacer(modifier = Modifier.height(4.dp))
+                OutlinedButton(onClick = onDismissRequest) { Text(stringResource(R.string.dialog_err_close)) }
+            }
+        }
+    }
+}

--- a/app/src/main/java/io/shubham0204/smollmandroid/ui/screens/chat/ChatActivity.kt
+++ b/app/src/main/java/io/shubham0204/smollmandroid/ui/screens/chat/ChatActivity.kt
@@ -105,6 +105,7 @@ import io.shubham0204.smollmandroid.data.Chat
 import io.shubham0204.smollmandroid.data.Task
 import io.shubham0204.smollmandroid.ui.components.AppBarTitleText
 import io.shubham0204.smollmandroid.ui.components.MediumLabelText
+import io.shubham0204.smollmandroid.ui.components.TextFieldDialog
 import io.shubham0204.smollmandroid.ui.screens.chat.ChatScreenViewModel.ModelLoadingState
 import io.shubham0204.smollmandroid.ui.screens.manage_tasks.ManageTasksActivity
 import io.shubham0204.smollmandroid.ui.screens.manage_tasks.TasksList
@@ -291,6 +292,9 @@ fun ChatActivityScreenUI(
             }
             SelectModelsList(viewModel)
             TasksListBottomSheet(viewModel)
+            ChangeFolderDialog(currChat!!, viewModel)
+            TextFieldDialog()
+            FolderOptionsDialog()
         }
     }
 }
@@ -443,6 +447,7 @@ private fun LazyItemScope.MessageListItem(
     allowEditing: Boolean,
 ) {
     var isEditing by remember { mutableStateOf(false) }
+    val context = LocalContext.current
     if (!isUserMessage) {
         Row(
             modifier =
@@ -578,7 +583,7 @@ private fun LazyItemScope.MessageListItem(
                         Spacer(modifier = Modifier.width(8.dp))
                         if (isEditing) {
                             Text(
-                                text = "Done",
+                                text = stringResource(R.string.edit_chat_message_done),
                                 modifier =
                                     Modifier.clickable {
                                         isEditing = false
@@ -588,7 +593,7 @@ private fun LazyItemScope.MessageListItem(
                             )
                             Spacer(modifier = Modifier.width(8.dp))
                             Text(
-                                text = "Cancel",
+                                text = context.getString(R.string.dialog_neg_cancel),
                                 modifier =
                                     Modifier.clickable {
                                         isEditing = false
@@ -598,7 +603,7 @@ private fun LazyItemScope.MessageListItem(
                             )
                         } else {
                             Text(
-                                text = "Edit",
+                                text = context.getString(R.string.dialog_edit_folder_button_text),
                                 modifier = Modifier.clickable { isEditing = true },
                                 fontSize = 6.sp,
                             )
@@ -806,6 +811,25 @@ private fun SelectModelsList(viewModel: ChatScreenViewModel) {
                         context.getString(R.string.chat_model_deleted, model.name),
                         Toast.LENGTH_LONG,
                     ).show()
+            },
+        )
+    }
+}
+
+@Composable
+private fun ChangeFolderDialog(
+    currentChat: Chat,
+    viewModel: ChatScreenViewModel,
+) {
+    val showChangeFolderDialogState by viewModel.showChangeFolderDialogState.collectAsStateWithLifecycle()
+    if (showChangeFolderDialogState) {
+        val folders by viewModel.appDB.getFolders().collectAsState(emptyList())
+        ChangeFolderDialogUI(
+            onDismissRequest = { viewModel.hideChangeFolderDialog() },
+            currentChat,
+            folders,
+            onUpdateFolderId = { folderId ->
+                viewModel.updateChatFolder(folderId)
             },
         )
     }

--- a/app/src/main/java/io/shubham0204/smollmandroid/ui/screens/chat/ChatListDrawer.kt
+++ b/app/src/main/java/io/shubham0204/smollmandroid/ui/screens/chat/ChatListDrawer.kt
@@ -17,6 +17,8 @@
 package io.shubham0204.smollmandroid.ui.screens.chat
 
 import android.text.format.DateUtils
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.slideInVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -33,6 +35,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyItemScope
@@ -40,27 +43,38 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.AddTask
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Quickreply
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import io.shubham0204.smollmandroid.R
 import io.shubham0204.smollmandroid.data.Chat
+import io.shubham0204.smollmandroid.data.Folder
 import io.shubham0204.smollmandroid.ui.components.AppAlertDialog
+import io.shubham0204.smollmandroid.ui.components.createAlertDialog
+import io.shubham0204.smollmandroid.ui.components.createTextFieldDialog
+import io.shubham0204.smollmandroid.ui.components.noRippleClickable
 
 @Composable
 fun DrawerUI(
@@ -125,43 +139,91 @@ private fun ColumnScope.ChatsList(
     onItemClick: (Chat) -> Unit,
 ) {
     val chats by viewModel.getChats().collectAsState(emptyList())
+    val folders by viewModel.getFolders().collectAsState(emptyList())
     val currentChat by viewModel.currChatState.collectAsState(null)
-    LazyColumn(modifier = Modifier.weight(1f)) {
-        item {
-            Row(
+    val context = LocalContext.current
+    Column {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .clickable { onManageTasksClick() },
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                Icons.Default.Quickreply,
+                contentDescription = "Manage Tasks",
+                tint = MaterialTheme.colorScheme.surfaceTint,
+            )
+            Text(
+                stringResource(R.string.chat_drawer_manage_tasks),
+                style = MaterialTheme.typography.labelLarge,
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .clickable { onManageTasksClick() },
-                verticalAlignment = Alignment.CenterVertically,
+                        .padding(8.dp),
+            )
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                stringResource(R.string.chat_drawer_folders),
+                style = MaterialTheme.typography.labelSmall,
+                modifier = Modifier.weight(1f),
+            )
+            IconButton(
+                onClick = {
+                    createTextFieldDialog(
+                        dialogTitle = context.getString(R.string.dialog_create_folder_title),
+                        dialogDefaultText = "",
+                        dialogPlaceholder = context.getString(R.string.dialog_create_folder_placeholder),
+                        dialogButtonText = context.getString(R.string.dialog_create_folder_button_text),
+                        onButtonClick = { text ->
+                            viewModel.appDB.addFolder(text)
+                        },
+                    )
+                },
             ) {
                 Icon(
-                    Icons.Default.Quickreply,
-                    contentDescription = "Manage Tasks",
+                    Icons.Default.Add,
+                    contentDescription = "Add Folder",
                     tint = MaterialTheme.colorScheme.surfaceTint,
                 )
+            }
+        }
+        folders.forEach { folder ->
+            val chatsInFolder by viewModel.getChatsForFolder(folder.id).collectAsState(emptyList())
+            FolderListItem(
+                folder = folder,
+                chatsInFolder = chatsInFolder,
+                onItemClick,
+                onEditFolderNameClick = { newName ->
+                    viewModel.appDB.updateFolder(folder.copy(name = newName))
+                },
+                onDeleteFolderClick = {
+                    viewModel.appDB.deleteFolder(folder.id)
+                },
+                onDeleteFolderWithChatsClick = {
+                    viewModel.appDB.deleteFolderWithChats(folder.id)
+                },
+            )
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        LazyColumn {
+            item {
                 Text(
-                    stringResource(R.string.chat_drawer_manage_tasks),
-                    style = MaterialTheme.typography.labelLarge,
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(8.dp),
+                    stringResource(R.string.chat_drawer_previous_chat),
+                    style = MaterialTheme.typography.labelSmall,
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+            }
+            items(chats) { chat ->
+                ChatListItem(
+                    chat,
+                    onItemClick,
+                    currentChat?.id == chat.id,
                 )
             }
-            Spacer(modifier = Modifier.height(16.dp))
-            Text(
-                stringResource(R.string.chat_drawer_previous_chat),
-                style = MaterialTheme.typography.labelSmall,
-            )
-            Spacer(modifier = Modifier.height(8.dp))
-        }
-        items(chats) { chat ->
-            ChatListItem(
-                chat,
-                onItemClick,
-                currentChat?.id == chat.id,
-            )
         }
     }
 }
@@ -203,6 +265,104 @@ private fun LazyItemScope.ChatListItem(
                             .background(MaterialTheme.colorScheme.tertiary, CircleShape)
                             .size(10.dp),
                 ) { }
+            }
+        }
+    }
+}
+
+@Composable
+private fun FolderListItem(
+    folder: Folder,
+    chatsInFolder: List<Chat>,
+    onChatItemClick: (Chat) -> Unit,
+    onEditFolderNameClick: (String) -> Unit,
+    onDeleteFolderClick: () -> Unit,
+    onDeleteFolderWithChatsClick: () -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val context = LocalContext.current
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Icon(
+            if (expanded) {
+                Icons.Default.KeyboardArrowDown
+            } else {
+                Icons.AutoMirrored.Filled.KeyboardArrowRight
+            },
+            contentDescription = "",
+            tint = MaterialTheme.colorScheme.surfaceTint,
+        )
+        Spacer(modifier = Modifier.width(4.dp))
+        Text(
+            folder.name,
+            modifier =
+                Modifier
+                    .noRippleClickable { expanded = !expanded }
+                    .weight(1f),
+        )
+        IconButton(onClick = {
+            createFolderOptionsDialog(
+                editFolderNameClick = {
+                    createTextFieldDialog(
+                        dialogTitle = context.getString(R.string.dialog_edit_folder_name_title),
+                        dialogPlaceholder = context.getString(R.string.dialog_create_folder_placeholder),
+                        dialogDefaultText = folder.name,
+                        dialogButtonText = context.getString(R.string.dialog_edit_folder_button_text),
+                        onButtonClick = { text ->
+                            onEditFolderNameClick(text)
+                        },
+                    )
+                },
+                deleteFolderClick = {
+                    createAlertDialog(
+                        dialogTitle = context.getString(R.string.dialog_delete_folder_title),
+                        dialogText =
+                            context.getString(
+                                R.string.dialog_delete_folder_text,
+                                folder.name,
+                            ),
+                        dialogPositiveButtonText = context.getString(R.string.dialog_pos_delete),
+                        onPositiveButtonClick = { onDeleteFolderClick() },
+                        dialogNegativeButtonText = context.getString(R.string.dialog_neg_cancel),
+                        onNegativeButtonClick = {},
+                    )
+                },
+                deleteFolderWithChatsClick = {
+                    createAlertDialog(
+                        dialogTitle = context.getString(R.string.dialog_delete_folder_with_chats_title),
+                        dialogText =
+                            context.getString(
+                                R.string.dialog_delete_folder_with_chats_text,
+                                folder.name,
+                            ),
+                        dialogPositiveButtonText = context.getString(R.string.dialog_pos_delete),
+                        onPositiveButtonClick = { onDeleteFolderWithChatsClick() },
+                        dialogNegativeButtonText = context.getString(R.string.dialog_neg_cancel),
+                        onNegativeButtonClick = {},
+                    )
+                },
+            )
+        }) {
+            Icon(
+                Icons.Default.MoreVert,
+                contentDescription = "Folder Options",
+                tint = MaterialTheme.colorScheme.surfaceTint,
+            )
+        }
+    }
+    AnimatedVisibility(
+        expanded,
+        enter = slideInVertically(),
+    ) {
+        LazyColumn {
+            items(chatsInFolder) {
+                Row {
+                    Spacer(modifier = Modifier.width(8.dp))
+                    ChatListItem(
+                        chat = it,
+                        onItemClick = onChatItemClick,
+                        isCurrentlySelected = false,
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/io/shubham0204/smollmandroid/ui/screens/chat/ChatMoreOptionsPopup.kt
+++ b/app/src/main/java/io/shubham0204/smollmandroid/ui/screens/chat/ChatMoreOptionsPopup.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.automirrored.filled.ShortText
 import androidx.compose.material.icons.filled.Assistant
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -51,6 +52,14 @@ fun ChatMoreOptionsPopup(
             text = { Text(stringResource(R.string.chat_options_edit_settings)) },
             onClick = {
                 onEditChatSettingsClick()
+                viewModel.hideMoreOptionsPopup()
+            },
+        )
+        DropdownMenuItem(
+            leadingIcon = { Icon(Icons.Default.Folder, contentDescription = "Change Folder") },
+            text = { Text(stringResource(R.string.chat_options_change_folder)) },
+            onClick = {
+                viewModel.showChangeFolderDialog()
                 viewModel.hideMoreOptionsPopup()
             },
         )

--- a/app/src/main/java/io/shubham0204/smollmandroid/ui/screens/chat/ChatScreenViewModel.kt
+++ b/app/src/main/java/io/shubham0204/smollmandroid/ui/screens/chat/ChatScreenViewModel.kt
@@ -39,6 +39,7 @@ import io.shubham0204.smollmandroid.R
 import io.shubham0204.smollmandroid.data.AppDB
 import io.shubham0204.smollmandroid.data.Chat
 import io.shubham0204.smollmandroid.data.ChatMessage
+import io.shubham0204.smollmandroid.data.Folder
 import io.shubham0204.smollmandroid.llm.ModelsRepository
 import io.shubham0204.smollmandroid.llm.SmolLMManager
 import io.shubham0204.smollmandroid.prism4j.PrismGrammarLocator
@@ -78,6 +79,9 @@ class ChatScreenViewModel(
 
     private val _partialResponse = MutableStateFlow("")
     val partialResponse: StateFlow<String> = _partialResponse
+
+    private val _showChangeFolderDialogState = MutableStateFlow(false)
+    val showChangeFolderDialogState: StateFlow<Boolean> = _showChangeFolderDialogState
 
     private val _showSelectModelListDialogState = MutableStateFlow(false)
     val showSelectModelListDialogState: StateFlow<Boolean> = _showSelectModelListDialogState
@@ -148,6 +152,10 @@ class ChatScreenViewModel(
 
     fun getChatMessages(chatId: Long): Flow<List<ChatMessage>> = appDB.getMessages(chatId)
 
+    fun getFolders(): Flow<List<Folder>> = appDB.getFolders()
+
+    fun getChatsForFolder(folderId: Long): Flow<List<Chat>> = appDB.getChatsForFolder(folderId)
+
     fun updateChatLLMParams(
         modelId: Long,
         chatTemplate: String,
@@ -155,6 +163,13 @@ class ChatScreenViewModel(
         _currChatState.value =
             _currChatState.value?.copy(llmModelId = modelId, chatTemplate = chatTemplate)
         appDB.updateChat(_currChatState.value!!)
+    }
+
+    fun updateChatFolder(folderId: Long) {
+        // TODO: Modifying currChatState triggers a model reload which is not
+        //       needed when folder is changed.
+        // _currChatState.value = _currChatState.value?.copy(folderId = folderId)
+        appDB.updateChat(_currChatState.value!!.copy(folderId = folderId))
     }
 
     fun updateChat(chat: Chat) {
@@ -333,6 +348,14 @@ class ChatScreenViewModel(
                 onNegativeButtonClick = null,
             )
         }
+    }
+
+    fun showChangeFolderDialog() {
+        _showChangeFolderDialogState.value = true
+    }
+
+    fun hideChangeFolderDialog() {
+        _showChangeFolderDialogState.value = false
     }
 
     fun showSelectModelListDialog() {

--- a/app/src/main/java/io/shubham0204/smollmandroid/ui/screens/chat/FolderOptionsDialog.kt
+++ b/app/src/main/java/io/shubham0204/smollmandroid/ui/screens/chat/FolderOptionsDialog.kt
@@ -1,0 +1,136 @@
+package io.shubham0204.smollmandroid.ui.screens.chat
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import io.shubham0204.smollmandroid.R
+
+private lateinit var onEditFolderNameClick: (() -> Unit)
+private lateinit var onDeleteFolderClick: (() -> Unit)
+private lateinit var onDeleteFolderWithChatsClick: (() -> Unit)
+private val textFieldDialogShowStatus = mutableStateOf(false)
+
+@Composable
+fun FolderOptionsDialog() {
+    var visible by remember { textFieldDialogShowStatus }
+    if (visible) {
+        Surface {
+            Dialog(onDismissRequest = { visible = false }) {
+                Column(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .background(
+                                MaterialTheme.colorScheme.surfaceContainer,
+                                RoundedCornerShape(8.dp),
+                            )
+                            .padding(16.dp),
+                ) {
+                    Row(
+                        modifier =
+                            Modifier
+                                .padding(8.dp)
+                                .clickable {
+                                    visible = false
+                                    onEditFolderNameClick()
+                                },
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Icon(
+                            Icons.Default.Edit,
+                            contentDescription = "Edit Folder Name",
+                            tint = MaterialTheme.colorScheme.surfaceTint,
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text(
+                            stringResource(R.string.dialog_folder_opts_edit),
+                            modifier = Modifier.weight(1f),
+                            style = MaterialTheme.typography.titleMedium,
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Row(
+                        modifier =
+                            Modifier
+                                .padding(8.dp)
+                                .clickable {
+                                    visible = false
+                                    onDeleteFolderClick()
+                                },
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Icon(
+                            Icons.Default.Delete,
+                            contentDescription = "Delete Folder",
+                            tint = MaterialTheme.colorScheme.surfaceTint,
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text(
+                            stringResource(R.string.dialog_folder_opts_delete_folder),
+                            modifier = Modifier.weight(1f),
+                            style = MaterialTheme.typography.titleMedium,
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Row(
+                        modifier =
+                            Modifier
+                                .padding(8.dp)
+                                .clickable {
+                                    visible = false
+                                    onDeleteFolderWithChatsClick()
+                                },
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Icon(
+                            Icons.Default.Delete,
+                            contentDescription = "Delete Folder With Chats",
+                            tint = MaterialTheme.colorScheme.surfaceTint,
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text(
+                            stringResource(R.string.dialog_folder_opts_delete_folder_chats),
+                            modifier = Modifier.weight(1f),
+                            style = MaterialTheme.typography.titleMedium,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+fun createFolderOptionsDialog(
+    editFolderNameClick: (() -> Unit),
+    deleteFolderClick: (() -> Unit),
+    deleteFolderWithChatsClick: (() -> Unit),
+) {
+    onEditFolderNameClick = editFolderNameClick
+    onDeleteFolderClick = deleteFolderClick
+    onDeleteFolderWithChatsClick = deleteFolderWithChatsClick
+    textFieldDialogShowStatus.value = true
+}

--- a/app/src/main/res/values-v23/strings.xml
+++ b/app/src/main/res/values-v23/strings.xml
@@ -2,4 +2,7 @@
 <resources>
     <string name="task_popup_add_shortcut">Add Shortcut</string>
     <string name="task_popup_remove_shortcut">Remove Shortcut</string>
+    <string name="chat_options_change_folder">Change Folder</string>
+    <string name="chat_drawer_folders">Folders</string>
+    <string name="dialog_select_folder_title">Select a Folder to store the chat</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -100,4 +100,20 @@
     <string name="dialog_pos_clear">清除</string>
     <string name="task_popup_add_shortcut">添加快捷方式</string>
     <string name="task_popup_remove_shortcut">删除快捷方式</string>
+    <string name="chat_options_change_folder">更改文件夹</string>
+    <string name="chat_drawer_folders">文件夹</string>
+    <string name="dialog_delete_folder_text">您确定要删除文件夹 \'%1$s\' 吗？删除该文件夹也会删除其中的所有聊天记录。</string>
+    <string name="dialog_select_folder_title">选择一个文件夹来存储聊天记录</string>
+    <string name="dialog_folder_opts_edit">编辑文件夹名称</string>
+    <string name="dialog_folder_opts_delete_folder">删除文件夹</string>
+    <string name="dialog_folder_opts_delete_folder_chats">删除文件夹及其聊天记录</string>
+    <string name="dialog_create_folder_title">创建文件夹</string>
+    <string name="dialog_create_folder_button_text">创建</string>
+    <string name="dialog_create_folder_placeholder">文件夹名称</string>
+    <string name="dialog_delete_folder_with_chats_text">您确定要删除文件夹 \'%1$s\' 吗？删除该文件夹也会删除其中的所有聊天记录。</string>
+    <string name="dialog_delete_folder_title">删除文件夹</string>
+    <string name="dialog_delete_folder_with_chats_title">删除文件夹及其聊天记录</string>
+    <string name="dialog_edit_folder_name_title">编辑文件夹名称</string>
+    <string name="dialog_edit_folder_button_text">编辑</string>
+    <string name="edit_chat_message_done">完成</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,4 +85,20 @@
     <string name="dialog_pos_clear">Clear</string>
     <string name="task_popup_add_shortcut">Add Shortcut</string>
     <string name="task_popup_remove_shortcut">Remove Shortcut</string>
+    <string name="chat_options_change_folder">Change Folder</string>
+    <string name="chat_drawer_folders">Folders</string>
+    <string name="dialog_delete_folder_text">Are you sure you want to delete the folder \'%1$s\'? Chats within the folder will not be deleted.</string>
+    <string name="dialog_delete_folder_with_chats_text">Are you sure you want to delete the folder \'%1$s\'? Deleting the folder will also delete all the chats in it.</string>
+    <string name="dialog_delete_folder_title">Delete Folder</string>
+    <string name="dialog_select_folder_title">Select a Folder to store the chat</string>
+    <string name="dialog_delete_folder_with_chats_title">Delete Folder With Chats</string>
+    <string name="dialog_folder_opts_edit">Edit Folder Name</string>
+    <string name="dialog_folder_opts_delete_folder">Delete Folder</string>
+    <string name="dialog_folder_opts_delete_folder_chats">Delete Folder With Chats</string>
+    <string name="dialog_create_folder_title">Create Folder</string>
+    <string name="dialog_create_folder_button_text">Create</string>
+    <string name="dialog_create_folder_placeholder">Folder Name</string>
+    <string name="dialog_edit_folder_name_title">Edit Folder Name</string>
+    <string name="dialog_edit_folder_button_text">Edit</string>
+    <string name="edit_chat_message_done">Done</string>
 </resources>


### PR DESCRIPTION
- add a new Folders table to store folder metadata
- add 'folderId' attribute to the Chat table
- update chat list drawer to show folders
- add dialog to create folders
- add dialog to show folder options (rename folder, delete folder, delete folder with chats)
- add ChangeFolderDialog to add/remove chat from folders