### PR TITLE
Fixed context length dialogue issue 

### DIFF
--- a/app/src/main/java/io/shubham0204/smollmandroid/ui/screens/chat/ChatScreenViewModel.kt
+++ b/app/src/main/java/io/shubham0204/smollmandroid/ui/screens/chat/ChatScreenViewModel.kt
@@ -243,7 +243,9 @@ class ChatScreenViewModel(
                     _isGeneratingResponse.value = false
                     responseGenerationsSpeed = response.generationSpeed
                     responseGenerationTimeSecs = response.generationTimeSecs
-                    appDB.updateChat(chat.copy(contextSizeConsumed = response.contextLengthUsed))
+                    val updatedChat = chat.copy(contextSizeConsumed = response.contextLengthUsed)
+                    _currChatState.value = updatedChat
+                    appDB.updateChat(updatedChat)
                 },
                 onCancelled = {
                     // ignore CancellationException, as it was called because


### PR DESCRIPTION
The database was being updated but not `_currChatState` , therefore the UI still held the old Chat object with the old context length

**Solution:**

Update the `_currChatState.value` immediately after updating the database.