### PR TITLE
Improve the copy and share functionality in UI

### DIFF
--- a/app/src/main/java/io/shubham0204/smollmandroid/ui/screens/chat/ChatActivity.kt
+++ b/app/src/main/java/io/shubham0204/smollmandroid/ui/screens/chat/ChatActivity.kt
@@ -486,7 +486,13 @@ private fun ColumnScope.MessagesList(
                 onCopyClicked = {
                     val clipboard =
                         context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-                    val clip = ClipData.newPlainText("Copied message", chatMessage.message)
+                    val plain =
+                        if (chatMessage.isUserMessage) {
+                            chatMessage.message
+                        } else {
+                            chatMessage.message.stripThinkingForClipboard()
+                        }
+                    val clip = ClipData.newPlainText("Copied message", plain)
                     clipboard.setPrimaryClip(clip)
                     Toast.makeText(
                             context,
@@ -496,10 +502,16 @@ private fun ColumnScope.MessagesList(
                         .show()
                 },
                 onShareClicked = {
+                    val plain =
+                        if (chatMessage.isUserMessage) {
+                            chatMessage.message
+                        } else {
+                            chatMessage.message.stripThinkingForClipboard()
+                        }
                     context.startActivity(
                         Intent(Intent.ACTION_SEND).apply {
                             type = "text/plain"
-                            putExtra(Intent.EXTRA_TEXT, chatMessage.message)
+                            putExtra(Intent.EXTRA_TEXT, plain)
                         }
                     )
                 },

--- a/app/src/main/java/io/shubham0204/smollmandroid/ui/screens/chat/ChatScreenViewModel.kt
+++ b/app/src/main/java/io/shubham0204/smollmandroid/ui/screens/chat/ChatScreenViewModel.kt
@@ -59,6 +59,9 @@ import kotlin.math.pow
 private const val LOGTAG = "[SmolLMAndroid-Kt]"
 private val LOGD: (String) -> Unit = { Log.d(LOGTAG, it) }
 
+private val findThinkHtmlBlockRegex = Regex("<blockquote><i><h6>[\\s\\S]*?</i></h6></blockquote>")
+internal fun String.stripThinkingForClipboard() = findThinkHtmlBlockRegex.replace(this, "").trim()
+
 sealed class ChatScreenUIEvent {
     sealed class ChatEvents {
         data class UpdateChatModel(val model: LLMModel) : ChatScreenUIEvent()


### PR DESCRIPTION
Hi @shubham0204,

This app has been helpful for me...

I noticed minor inconvenience when copying/sharing of llm chat ouputs where thinking text is also copied/shared.
For this made changes to only copy the text we need and not the thinking text.

Please find the tested changes screen recordings during base and modified changes for copy and share scenarios:

https://github.com/user-attachments/assets/0545003d-15da-411a-b6f0-11d50326e567


https://github.com/user-attachments/assets/e732bac2-ac4e-4c51-9f1b-bea61fd11376


https://github.com/user-attachments/assets/2eb18496-1872-42a5-bfcf-e85b69a66a4e


https://github.com/user-attachments/assets/fd540d5d-7af5-46f3-bf5a-e27106e93d59

Good day!