### PR TITLE
Add capability to refer models from external storage

### DIFF
--- a/app/src/main/java/io/shubham0204/smollmandroid/ui/screens/model_download/DownloadModelActivity.kt
+++ b/app/src/main/java/io/shubham0204/smollmandroid/ui/screens/model_download/DownloadModelActivity.kt
@@ -181,9 +181,10 @@ class DownloadModelActivity : ComponentActivity() {
                                     addNewModelStep = AddNewModelStep.DownloadModel
                                 },
                                 checkGGUFFile = ::checkGGUFFile,
-                                copyModelFile = { modelFileUri ->
-                                    viewModel.copyModelFile(
+                                processModelFile = { modelFileUri, isUriPersisted ->
+                                    viewModel.processModelFile(
                                         modelFileUri,
+                                        isUriPersisted,
                                         onComplete = { openChatActivity() },
                                     )
                                 },

--- a/app/src/main/java/io/shubham0204/smollmandroid/ui/screens/model_download/DownloadModelsViewModel.kt
+++ b/app/src/main/java/io/shubham0204/smollmandroid/ui/screens/model_download/DownloadModelsViewModel.kt
@@ -20,7 +20,6 @@ import android.app.DownloadManager
 import android.content.Context
 import android.net.Uri
 import android.os.Environment
-import android.provider.OpenableColumns
 import android.widget.Toast
 import androidx.core.net.toUri
 import androidx.lifecycle.ViewModel
@@ -38,6 +37,7 @@ import io.shubham0204.smollmandroid.ui.components.hideProgressDialog
 import io.shubham0204.smollmandroid.ui.components.setProgressDialogText
 import io.shubham0204.smollmandroid.ui.components.setProgressDialogTitle
 import io.shubham0204.smollmandroid.ui.components.showProgressDialog
+import io.shubham0204.smollmandroid.utils.FileUtils
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -46,10 +46,8 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import org.koin.core.annotation.Single
 import java.io.File
-import java.io.FileOutputStream
 import java.net.HttpURLConnection
 import java.net.URL
-import java.nio.file.Paths
 
 @Single
 class DownloadModelsViewModel(
@@ -109,43 +107,42 @@ class DownloadModelsViewModel(
      * add a new LLMModel entity with modelName=fileName where fileName is the name of the model
      * file.
      */
-    fun copyModelFile(uri: Uri, onComplete: () -> Unit) {
-        var fileName = ""
-        context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
-            val nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
-            cursor.moveToFirst()
-            fileName = cursor.getString(nameIndex)
-        }
-        if (fileName.isNotEmpty()) {
-            setProgressDialogTitle(context.getString(R.string.dialog_progress_copy_model_title))
-            setProgressDialogText(
-                context.getString(R.string.dialog_progress_copy_model_text, fileName)
-            )
-            showProgressDialog()
-            CoroutineScope(Dispatchers.IO).launch {
-                context.contentResolver.openInputStream(uri).use { inputStream ->
-                    FileOutputStream(File(context.filesDir, fileName)).use { outputStream ->
-                        inputStream?.copyTo(outputStream)
-                    }
-                }
-                val ggufReader = GGUFReader()
-                ggufReader.load(File(context.filesDir, fileName).absolutePath)
-                val contextSize =
-                    ggufReader.getContextSize() ?: SmolLM.DefaultInferenceParams.contextSize
-                val chatTemplate =
-                    ggufReader.getChatTemplate() ?: SmolLM.DefaultInferenceParams.chatTemplate
-                appDB.addModel(
-                    fileName,
-                    "",
-                    Paths.get(context.filesDir.absolutePath, fileName).toString(),
-                    contextSize.toInt(),
-                    chatTemplate,
+    fun processModelFile(fileUri: Uri, isUriPersisted: Boolean, onComplete: () -> Unit) {
+        val fileName = FileUtils.getFileNameFromUri(context, fileUri)
+        if (!fileName.isNullOrBlank()) {
+            var modelPath = ""
+            if (!isUriPersisted) {
+                setProgressDialogTitle(context.getString(R.string.dialog_progress_copy_model_title))
+                setProgressDialogText(
+                    context.getString(R.string.dialog_progress_copy_model_text, fileName)
                 )
-                withContext(Dispatchers.Main) {
-                    hideProgressDialog()
-                    onComplete()
+                showProgressDialog()
+                runBlocking(Dispatchers.IO) {
+                    FileUtils.copyFile(context, fileUri, fileName)
+                }
+                modelPath = File(context.filesDir, fileName).absolutePath
+                hideProgressDialog()
+            } else {
+                modelPath = FileUtils.getFilePathFromUri(context, fileUri) ?: ""
+            }
+            runBlocking(Dispatchers.IO) {
+                val ggufReader = GGUFReader()
+                if (modelPath.isNotEmpty()) {
+                    ggufReader.load(modelPath)
+                    val contextSize =
+                        ggufReader.getContextSize() ?: SmolLM.DefaultInferenceParams.contextSize
+                    val chatTemplate =
+                        ggufReader.getChatTemplate() ?: SmolLM.DefaultInferenceParams.chatTemplate
+                    appDB.addModel(
+                        fileName,
+                        "",
+                        modelPath,
+                        contextSize.toInt(),
+                        chatTemplate,
+                    )
                 }
             }
+            onComplete()
         } else {
             Toast.makeText(
                     context,

--- a/app/src/main/java/io/shubham0204/smollmandroid/ui/screens/model_download/ImportModelScreen.kt
+++ b/app/src/main/java/io/shubham0204/smollmandroid/ui/screens/model_download/ImportModelScreen.kt
@@ -6,6 +6,7 @@ import android.os.Environment
 import android.provider.DocumentsContract
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -20,14 +21,20 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
 import androidx.core.net.toUri
 import compose.icons.FeatherIcons
 import compose.icons.feathericons.ArrowLeft
@@ -39,23 +46,39 @@ import io.shubham0204.smollmandroid.ui.components.createAlertDialog
 @Preview
 @Composable
 private fun PreviewImportModelScreen() {
-    ImportModelScreen(onPrevSectionClick = {}, checkGGUFFile = { false }, copyModelFile = {})
+    ImportModelScreen(
+        onPrevSectionClick = {},
+        checkGGUFFile = { false },
+        processModelFile = { _, _ -> })
 }
+
+private val MAKE_PERSISTENT_URI_KEY: String = "persist"
 
 @Composable
 fun ImportModelScreen(
     onPrevSectionClick: () -> Unit,
     checkGGUFFile: (Uri) -> Boolean,
-    copyModelFile: (Uri) -> Unit,
+    processModelFile: (Uri, Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    var isDialogVisible by remember { mutableStateOf(false) }
+    var shouldPersistUri by remember { mutableStateOf(false) }
+
     val context = LocalContext.current
     val launcher =
         rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) { activityResult ->
             activityResult.data?.let {
                 it.data?.let { uri ->
+                    if (shouldPersistUri) {
+                        val takeFlags: Int =
+                            Intent.FLAG_GRANT_READ_URI_PERMISSION or
+                                    Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                        val contentResolver = context.contentResolver
+                        contentResolver.takePersistableUriPermission(uri, takeFlags)
+                    }
+
                     if (checkGGUFFile(uri)) {
-                        copyModelFile(uri)
+                        processModelFile(uri, shouldPersistUri)
                     } else {
                         createAlertDialog(
                             dialogTitle = context.getString(R.string.dialog_invalid_file_title),
@@ -71,57 +94,46 @@ fun ImportModelScreen(
         }
     Column(
         modifier = modifier.padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp)
+        verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         Column {
             Text(
                 text = stringResource(R.string.import_model_step_title),
                 style = MaterialTheme.typography.headlineSmall,
-                fontWeight = FontWeight.Bold
+                fontWeight = FontWeight.Bold,
             )
             Text(
                 text = stringResource(R.string.import_model_step_des),
                 style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
 
         Surface(
             color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f),
             shape = RoundedCornerShape(16.dp),
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth(),
         ) {
             Column(
                 modifier = Modifier.padding(24.dp),
                 horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(16.dp)
+                verticalArrangement = Arrangement.spacedBy(16.dp),
             ) {
                 Icon(
                     FeatherIcons.FilePlus,
                     contentDescription = null,
                     modifier = Modifier.padding(12.dp),
-                    tint = MaterialTheme.colorScheme.primary
+                    tint = MaterialTheme.colorScheme.primary,
                 )
                 Text(
                     text = "Select a .gguf file from your storage to import it into SmolChat.",
                     style = MaterialTheme.typography.bodyMedium,
                     textAlign = TextAlign.Center,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
                 Button(
                     onClick = {
-                        val intent =
-                            Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
-                                setType("application/octet-stream")
-                                putExtra(
-                                    DocumentsContract.EXTRA_INITIAL_URI,
-                                    Environment.getExternalStoragePublicDirectory(
-                                        Environment.DIRECTORY_DOWNLOADS
-                                    )
-                                        .toUri(),
-                                )
-                            }
-                        launcher.launch(intent)
+                        isDialogVisible = true
                     },
                     shape = RoundedCornerShape(12.dp),
                 ) {
@@ -134,16 +146,55 @@ fun ImportModelScreen(
 
         Row(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.Center
+            horizontalArrangement = Arrangement.Center,
         ) {
             OutlinedButton(
                 onClick = onPrevSectionClick,
-                shape = RoundedCornerShape(12.dp)
+                shape = RoundedCornerShape(12.dp),
             ) {
                 Icon(FeatherIcons.ArrowLeft, contentDescription = null)
                 AppSpacer4W()
                 Text(stringResource(R.string.button_text_back))
             }
         }
+
+        if (isDialogVisible) {
+            Dialog(
+                onDismissRequest = { isDialogVisible = false }
+            ) {
+                Column(modifier = Modifier.background(Color.White)) {
+                    Text("Do you want to refer the file or copy it?")
+                    Button(
+                        onClick = {
+                            isDialogVisible = false
+                            shouldPersistUri = true
+                            launcher.launch(makeIntent())
+                        }
+                    ) {
+                        Text("Refer File")
+                    }
+
+                    Button(
+                        onClick = {
+                            isDialogVisible = false
+                            shouldPersistUri = false
+                            launcher.launch(makeIntent())
+                        }
+                    ) {
+                        Text("Copy File")
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun makeIntent(): Intent {
+    return Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
+        setType("application/octet-stream")
+        putExtra(
+            DocumentsContract.EXTRA_INITIAL_URI,
+            Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).toUri(),
+        )
     }
 }

--- a/app/src/main/java/io/shubham0204/smollmandroid/utils/FileUtils.kt
+++ b/app/src/main/java/io/shubham0204/smollmandroid/utils/FileUtils.kt
@@ -1,0 +1,55 @@
+package io.shubham0204.smollmandroid.utils
+
+import android.content.Context
+import android.net.Uri
+import android.provider.OpenableColumns
+import java.io.File
+import java.io.FileOutputStream
+
+class FileUtils {
+    companion object {
+        /**
+         * Copies a file from a given [Uri] to the application's internal storage directory.
+         *
+         * @param context The context used to access the content resolver and internal files directory.
+         * @param fileUri The [Uri] of the source file to be copied.
+         * @param fileName The name to be assigned to the copied file within [Context.getFilesDir].
+         */
+        fun copyFile(context: Context, fileUri: Uri, fileName: String) {
+            context.contentResolver.openInputStream(fileUri)?.use { inputStream ->
+                FileOutputStream(File(context.filesDir, fileName)).use { outputStream ->
+                    inputStream.copyTo(outputStream)
+                }
+            }
+        }
+
+
+        /**
+         * Retrieves the display name (file name) from a given [Uri].
+         *
+         * This method queries the [android.content.ContentResolver] to find the
+         * [android.provider.OpenableColumns.DISPLAY_NAME] associated with the provided URI.
+         *
+         * @param context The context used to access the ContentResolver.
+         * @param uri The [Uri] of the file.
+         * @return The file name as a [String], or null if the column is not present or the query fails.
+         */
+        fun getFileNameFromUri(context: Context, uri: Uri): String? {
+            var fileName: String? = null
+            context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
+                val nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                if (cursor.moveToFirst()) {
+                    fileName = cursor.getString(nameIndex)
+                }
+            }
+            return fileName
+        }
+
+        fun getFilePathFromUri(context: Context, uri: Uri): String {
+            val contentResolver = context.contentResolver
+            val fd = contentResolver.openFileDescriptor(uri, "r")
+            val detachedFd = fd?.detachFd()
+            return "/proc/self/fd/$detachedFd"
+        }
+    }
+}

--- a/smollm/src/main/java/io/shubham0204/smollm/GGUFReader.kt
+++ b/smollm/src/main/java/io/shubham0204/smollm/GGUFReader.kt
@@ -28,8 +28,11 @@ class GGUFReader {
 
     private var nativeHandle: Long = 0L
 
-    suspend fun load(modelPath: String) =
-        withContext(Dispatchers.IO) { nativeHandle = getGGUFContextNativeHandle(modelPath) }
+    suspend fun load(modelPath: String): Boolean =
+        withContext(Dispatchers.IO) {
+            nativeHandle = getGGUFContextNativeHandle(modelPath)
+            nativeHandle != 0L
+        }
 
     fun getContextSize(): Long? {
         assert(nativeHandle != 0L) { "Use GGUFReader.load() to initialize the reader" }

--- a/smollm/src/main/java/io/shubham0204/smollm/SmolLM.kt
+++ b/smollm/src/main/java/io/shubham0204/smollm/SmolLM.kt
@@ -179,10 +179,19 @@ class SmolLM {
     suspend fun load(modelPath: String, params: InferenceParams = InferenceParams()) =
         withContext(Dispatchers.IO) {
             val ggufReader = GGUFReader()
-            ggufReader.load(modelPath)
-            val modelContextSize = ggufReader.getContextSize() ?: DefaultInferenceParams.contextSize
+            val isLoaded = ggufReader.load(modelPath)
+            val modelContextSize =
+                if (isLoaded) {
+                    ggufReader.getContextSize() ?: DefaultInferenceParams.contextSize
+                } else {
+                    DefaultInferenceParams.contextSize
+                }
             val modelChatTemplate =
-                ggufReader.getChatTemplate() ?: DefaultInferenceParams.chatTemplate
+                if (isLoaded) {
+                    ggufReader.getChatTemplate() ?: DefaultInferenceParams.chatTemplate
+                } else {
+                    DefaultInferenceParams.chatTemplate
+                }
             nativePtr =
                 loadModel(
                     modelPath,


### PR DESCRIPTION
Instead of copying models to the app's internal storage, persist the Uri of the selected model (using ContentResolver) and use it to load the model